### PR TITLE
Add necessary forward declarations

### DIFF
--- a/yappcap.pyx
+++ b/yappcap.pyx
@@ -59,6 +59,10 @@ cdef void __pcap_callback_fn(unsigned char *user, const_pcap_pkthdr_ptr pkthdr, 
     if pcap.__dumper:
         pcap.__dumper.dump(pkt)
 
+cdef class PcapDumper
+
+cdef class BpfProgram
+
 # Things that work with all pcap_t
 cdef class Pcap(object):
     """Generic Pcap object. Instantiate via PcapLive or PcapOffline"""


### PR DESCRIPTION
The Pcap class has members of the PcapDumper and BpfProgram types, but these
classes are not defined until after the Pcap class (due to circular dependencies).
In order to correct this, add forward declarations for them before the Pcap
class is defined.
